### PR TITLE
[Refactor] Integrate with PipeRider Compare Action

### DIFF
--- a/.github/workflows/pr-compare.yml
+++ b/.github/workflows/pr-compare.yml
@@ -17,12 +17,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: setup and prep data
       run: |
-        pip install -r requirements.txt
-        dbt deps
         mkdir data
-        curl -o data/incomes.csv https://lydata.ronny-s3.click/incomes.csv
-        curl -o data/expenditures.csv https://lydata.ronny-s3.click/expenditures.csv
-        dbt seed
+        curl -o data/incomes.csv https://tw-campaign-finance.s3.ap-northeast-1.amazonaws.com/incomes.csv
+        curl -o data/expenditures.csv https://tw-campaign-finance.s3.ap-northeast-1.amazonaws.com/expenditures.csv
 
     - name: PipeRider Compare
       uses: InfuseAI/piperider-compare-action@v1

--- a/profiles.yml
+++ b/profiles.yml
@@ -2,7 +2,7 @@ tw_campaign_finance:
   outputs:
     dev:
       type: duckdb
-      path: target/duckdb.db
+      path: tw_campaign_finance.duckdb
       extensions:
         - httpfs
         - parquet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-dbt-duckdb
+dbt-core==1.5.3
+dbt-duckdb==1.5.2
 piperider[duckdb]


### PR DESCRIPTION
 - Change the location of duckdb from `target/duckdb.db` to `tw_campaign_finance.duckdb`
 - Remove manually run `dbt seed` in the action workflow. The PipeRider compare action will do this task during `dbt build`.
 - Fix dbt-core and dbt-duckdb version