### PR TITLE
Add version tag

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -1,3 +1,5 @@
+version: 2
+
 sources:
   - name: cy
     tables:


### PR DESCRIPTION
We need a version tag for `dbt-1.4`

```
(venv) (⎈ |kind-kind:default)(base) ➜  tw_campaign_finance git:(main) ✗ dbt compile
02:52:06  Running with dbt=1.4.7
02:52:06  Unable to do partial parsing because profile has changed
02:52:07  Encountered an error:
Compilation Error
  The yml property file at models/schema.yml is invalid because the yml property file models/schema.yml is missing a version tag. Please consult the documentation for more information on yml property file syntax:

  https://docs.getdbt.com/reference/configs-and-properties
```